### PR TITLE
Add admin category CRUD controls

### DIFF
--- a/database/orm_query.py
+++ b/database/orm_query.py
@@ -102,6 +102,31 @@ async def orm_create_categories(session: AsyncSession, categories: list):
     session.add_all([Category(name=name) for name in categories])
     await session.commit()
 
+
+async def orm_add_category(session: AsyncSession, name: str) -> Category:
+    category = Category(name=name)
+    session.add(category)
+    await session.commit()
+    await session.refresh(category)
+    return category
+
+
+async def orm_update_category(session: AsyncSession, category_id: int, name: str) -> bool:
+    query = (
+        update(Category)
+        .where(Category.id == category_id)
+        .values(name=name)
+    )
+    result = await session.execute(query)
+    await session.commit()
+    return result.rowcount > 0
+
+
+async def orm_delete_category(session: AsyncSession, category_id: int) -> bool:
+    result = await session.execute(delete(Category).where(Category.id == category_id))
+    await session.commit()
+    return result.rowcount > 0
+
 ############ Админка: добавить/изменить/удалить товар ########################
 
 async def orm_add_product(session: AsyncSession, data: dict):

--- a/handlers/admin_private.py
+++ b/handlers/admin_private.py
@@ -7,13 +7,16 @@ from aiogram.types import ReplyKeyboardRemove
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from database.orm_query import (
-    orm_change_banner_image,
-    orm_get_categories,
+    orm_add_category,
     orm_add_product,
+    orm_change_banner_image,
+    orm_delete_category,
     orm_delete_product,
+    orm_get_categories,
     orm_get_info_pages,
     orm_get_product,
     orm_get_products,
+    orm_update_category,
     orm_update_product,
 )
 
@@ -29,12 +32,15 @@ admin_router.message.filter(ChatTypeFilter(["private"]), IsAdmin())
 ADMIN_MAIN_BTNS = {
     "Добавить товар": "admin_add_product",
     "Ассортимент": "admin_catalog",
+    "Добавить категорию": "admin_add_category",
+    "Переименовать категорию": "admin_rename_category",
+    "Удалить категорию": "admin_delete_category",
     "Добавить/Изменить баннер": "admin_banner",
 }
 
 
 def get_admin_main_keyboard() -> types.InlineKeyboardMarkup:
-    return get_callback_btns(btns=ADMIN_MAIN_BTNS, sizes=(2, 1))
+    return get_callback_btns(btns=ADMIN_MAIN_BTNS, sizes=(2, 2))
 
 
 async def send_admin_menu(message: types.Message) -> None:
@@ -52,7 +58,8 @@ async def admin_features(message: types.Message):
 
 
 @admin_router.callback_query(F.data == "admin_menu")
-async def show_admin_menu(callback: types.CallbackQuery):
+async def show_admin_menu(callback: types.CallbackQuery, state: FSMContext):
+    await state.clear()
     await send_admin_menu(callback.message)
     await callback.answer()
 
@@ -142,6 +149,223 @@ async def cancel_handler(message: types.Message, state: FSMContext) -> None:
 @admin_router.message(AddBanner.image)
 async def add_banner2(message: types.Message, state: FSMContext):
     await message.answer("Отправьте фото баннера или отмена")
+
+#########################################################################################
+
+
+########################## Управление категориями ######################################
+
+
+class CategoryAdd(StatesGroup):
+    name = State()
+
+
+class CategoryRename(StatesGroup):
+    category = State()
+    name = State()
+
+
+class CategoryDelete(StatesGroup):
+    category = State()
+
+
+@admin_router.callback_query(StateFilter(None), F.data == "admin_add_category")
+async def start_category_add(callback: types.CallbackQuery, state: FSMContext):
+    await callback.message.answer(
+        "Введите название новой категории",
+        reply_markup=types.ReplyKeyboardRemove(),
+    )
+    await state.set_state(CategoryAdd.name)
+    await callback.answer()
+
+
+@admin_router.message(CategoryAdd.name, F.text)
+async def process_category_add(
+    message: types.Message, state: FSMContext, session: AsyncSession
+):
+    name = message.text.strip()
+
+    if not name:
+        await message.answer("Название категории не может быть пустым. Введите заново.")
+        return
+
+    if len(name) > 150:
+        await message.answer("Название категории не должно превышать 150 символов. Введите заново.")
+        return
+
+    categories = await orm_get_categories(session)
+    if any(category.name.casefold() == name.casefold() for category in categories):
+        await message.answer("Категория с таким названием уже существует. Введите другое название.")
+        return
+
+    category = await orm_add_category(session, name)
+    await message.answer(
+        f'Категория "{category.name}" добавлена.',
+        reply_markup=get_admin_main_keyboard(),
+    )
+    await state.clear()
+
+
+@admin_router.message(CategoryAdd.name)
+async def process_category_add_invalid(message: types.Message):
+    await message.answer("Введите текстовое название категории или напишите \"отмена\".")
+
+
+@admin_router.callback_query(StateFilter(None), F.data == "admin_rename_category")
+async def start_category_rename(
+    callback: types.CallbackQuery, state: FSMContext, session: AsyncSession
+):
+    categories = await orm_get_categories(session)
+    if not categories:
+        await callback.message.answer(
+            "Категории отсутствуют. Добавьте новую категорию.",
+            reply_markup=get_admin_main_keyboard(),
+        )
+        await callback.answer()
+        return
+
+    btns = {category.name: f"admin_rename_category_{category.id}" for category in categories}
+    btns["⬅️ Админ меню"] = "admin_menu"
+    await callback.message.answer(
+        "Выберите категорию для переименования",
+        reply_markup=get_callback_btns(btns=btns),
+    )
+    await state.set_state(CategoryRename.category)
+    await callback.answer()
+
+
+@admin_router.callback_query(CategoryRename.category, F.data.startswith("admin_rename_category_"))
+async def choose_category_for_rename(
+    callback: types.CallbackQuery, state: FSMContext, session: AsyncSession
+):
+    category_id = int(callback.data.split("_")[-1])
+
+    categories = await orm_get_categories(session)
+    category = next((item for item in categories if item.id == category_id), None)
+    if category is None:
+        await callback.answer("Категория не найдена.", show_alert=True)
+        return
+
+    await callback.message.edit_reply_markup()
+    await state.update_data(category_id=category_id, old_name=category.name)
+    await callback.message.answer(
+        f'Введите новое название для категории "{category.name}"',
+        reply_markup=types.ReplyKeyboardRemove(),
+    )
+    await state.set_state(CategoryRename.name)
+    await callback.answer()
+
+
+@admin_router.message(CategoryRename.name, F.text)
+async def process_category_rename(
+    message: types.Message, state: FSMContext, session: AsyncSession
+):
+    new_name = message.text.strip()
+
+    if not new_name:
+        await message.answer("Название категории не может быть пустым. Введите заново.")
+        return
+
+    if len(new_name) > 150:
+        await message.answer(
+            "Название категории не должно превышать 150 символов. Введите другое название."
+        )
+        return
+
+    data = await state.get_data()
+    category_id = data.get("category_id")
+    old_name = data.get("old_name", "")
+
+    if category_id is None:
+        await message.answer(
+            "Не удалось определить категорию для переименования. Начните заново.",
+            reply_markup=get_admin_main_keyboard(),
+        )
+        await state.clear()
+        return
+
+    categories = await orm_get_categories(session)
+    if any(
+        category.id != category_id and category.name.casefold() == new_name.casefold()
+        for category in categories
+    ):
+        await message.answer("Категория с таким названием уже существует. Введите другое название.")
+        return
+
+    updated = await orm_update_category(session, int(category_id), new_name)
+    if not updated:
+        await message.answer(
+            "Не удалось переименовать категорию. Попробуйте позже.",
+            reply_markup=get_admin_main_keyboard(),
+        )
+        await state.clear()
+        return
+
+    await message.answer(
+        f'Категория "{old_name}" переименована в "{new_name}".',
+        reply_markup=get_admin_main_keyboard(),
+    )
+    await state.clear()
+
+
+@admin_router.message(CategoryRename.name)
+async def process_category_rename_invalid(message: types.Message):
+    await message.answer("Введите текстовое название категории или напишите \"отмена\".")
+
+
+@admin_router.callback_query(StateFilter(None), F.data == "admin_delete_category")
+async def start_category_delete(
+    callback: types.CallbackQuery, state: FSMContext, session: AsyncSession
+):
+    categories = await orm_get_categories(session)
+    if not categories:
+        await callback.message.answer(
+            "Категории отсутствуют. Добавлять пока нечего удалять.",
+            reply_markup=get_admin_main_keyboard(),
+        )
+        await callback.answer()
+        return
+
+    btns = {category.name: f"admin_delete_category_{category.id}" for category in categories}
+    btns["⬅️ Админ меню"] = "admin_menu"
+    await callback.message.answer(
+        "Выберите категорию для удаления",
+        reply_markup=get_callback_btns(btns=btns),
+    )
+    await state.set_state(CategoryDelete.category)
+    await callback.answer()
+
+
+@admin_router.callback_query(CategoryDelete.category, F.data.startswith("admin_delete_category_"))
+async def process_category_delete(
+    callback: types.CallbackQuery, state: FSMContext, session: AsyncSession
+):
+    category_id = int(callback.data.split("_")[-1])
+
+    categories = await orm_get_categories(session)
+    category = next((item for item in categories if item.id == category_id), None)
+    if category is None:
+        await callback.answer("Категория не найдена.", show_alert=True)
+        return
+
+    await callback.message.edit_reply_markup()
+    deleted = await orm_delete_category(session, category_id)
+
+    if deleted:
+        await callback.answer("Категория удалена")
+        await callback.message.answer(
+            f'Категория "{category.name}" удалена.',
+            reply_markup=get_admin_main_keyboard(),
+        )
+    else:
+        await callback.answer("Не удалось удалить категорию", show_alert=True)
+        await callback.message.answer(
+            "Не удалось удалить категорию. Попробуйте позже.",
+            reply_markup=get_admin_main_keyboard(),
+        )
+
+    await state.clear()
+
 
 #########################################################################################
 

--- a/kbds/inline.py
+++ b/kbds/inline.py
@@ -142,10 +142,19 @@ def get_user_cart(
         return keyboard.adjust(*sizes).as_markup()
 
 
-def get_callback_btns(*, btns: dict[str, str], sizes: tuple[int] = (2,)):
+def get_callback_btns(*, btns: dict[str, str], sizes: tuple[int, ...] = (2,)):
     keyboard = InlineKeyboardBuilder()
 
     for text, data in btns.items():
         keyboard.add(InlineKeyboardButton(text=text, callback_data=data))
 
-    return keyboard.adjust(*sizes).as_markup()
+    total_btns = len(btns)
+    row_sizes = list(sizes) if sizes else []
+
+    if not row_sizes:
+        row_sizes.append(total_btns or 1)
+
+    if total_btns and sum(row_sizes) < total_btns:
+        row_sizes.append(total_btns - sum(row_sizes))
+
+    return keyboard.adjust(*row_sizes).as_markup()


### PR DESCRIPTION
## Summary
- add category CRUD helpers to the ORM layer
- extend the admin inline menu with FSM flows for creating, renaming and deleting categories
- adjust the inline keyboard builder to better lay out dynamic button sets

## Testing
- python -m compileall database handlers kbds

------
https://chatgpt.com/codex/tasks/task_e_68cc57937810832d8e491d310acbcaae