### PR TITLE
Decorate order confirmation and admin notifications with emojis

### DIFF
--- a/handlers/order_processing.py
+++ b/handlers/order_processing.py
@@ -46,17 +46,25 @@ class OrderState(StatesGroup):
     confirm = State()
 def build_cart_block(lines: list[str]) -> str:
     if not lines:
-        return "Корзина пуста."
-    return "\n".join(f"• {line}" for line in lines)
+        return "🧺 Корзина пуста."
+    formatted_lines: list[str] = []
+    for line in lines:
+        prefix, separator, rest = line.partition(". ")
+        if separator and prefix.isdigit():
+            decorated = f"{prefix}. 🛍️ {rest}"
+        else:
+            decorated = f"🛍️ {line}"
+        formatted_lines.append(f"• {decorated}")
+    return "\n".join(formatted_lines)
 
 
 def build_review_text(cart_lines: list[str], total_text: str) -> str:
     cart_text = build_cart_block(cart_lines)
     return (
-        "<strong>Оформление заказа</strong>\n\n"
-        "Проверьте содержимое корзины перед оформлением.\n\n"
-        f"<strong>Корзина:</strong>\n{cart_text}\n\n"
-        f"<strong>Итого:</strong> {total_text}$\n\n"
+        "🛍️ <strong>Оформление заказа</strong>\n\n"
+        "🔎 Проверьте содержимое корзины перед оформлением.\n\n"
+        f"🧺 <strong>Корзина:</strong>\n{cart_text}\n\n"
+        f"💳 <strong>Итого:</strong> {total_text}$\n\n"
         "Нажмите «Подтвердить», чтобы продолжить, или «Назад», чтобы вернуться."
     )
 
@@ -224,21 +232,22 @@ def order_summary_text(data: dict) -> str:
     phone = data.get("phone") or "—"
 
     return (
-        "<strong>Проверьте данные заказа</strong>\n\n"
-        f"ФИО: {full_name}\n"
-        f"Индекс: {postal_code}\n"
-        f"Телефон: {phone}\n\n"
-        f"<strong>Корзина:</strong>\n{cart_block}\n\n"
-        f"<strong>Итого:</strong> {total}$"
+        "🔎 <strong>Проверьте данные заказа</strong>\n\n"
+        f"👤 <strong>ФИО:</strong> {full_name}\n"
+        f"📮 <strong>Индекс:</strong> {postal_code}\n"
+        f"📞 <strong>Телефон:</strong> {phone}\n\n"
+        f"🧺 <strong>Корзина:</strong>\n{cart_block}\n\n"
+        f"💰 <strong>Итого:</strong> {total}$"
     )
 
 
 def completion_text(data: dict) -> str:
     summary = order_summary_text(data)
     return (
-        "<strong>Заказ оформлен!</strong>\n\n"
+        "🎉 <strong>Заказ оформлен!</strong>\n\n"
         f"{summary}\n\n"
-        "Наш менеджер свяжется с вами для подтверждения."
+        "🤝 Наш менеджер свяжется с вами для подтверждения.\n"
+        "Спасибо, что выбрали нас! 💚"
     )
 
 

--- a/utils/order.py
+++ b/utils/order.py
@@ -154,14 +154,14 @@ async def ensure_cart_data(
 
 
 def build_admin_notification(order_id: int, customer: CustomerData, cart: CartData) -> str:
-    items_block = "\n".join(f"• {line}" for line in cart.lines) if cart.lines else "—"
+    items_block = "\n".join(f"🛍️ {line}" for line in cart.lines) if cart.lines else "—"
     return (
-        f"Новый заказ №{order_id}\n"
-        f"ФИО: {customer.full_name}\n"
-        f"Индекс: {customer.postal_code}\n"
-        f"Телефон: {customer.phone_for_display}\n\n"
-        f"Товары:\n{items_block}\n\n"
-        f"Итого: {cart.total_text}$"
+        f"📦 <strong>Новый заказ №{order_id}</strong>\n"
+        f"👤 <strong>ФИО:</strong> {customer.full_name}\n"
+        f"📮 <strong>Индекс:</strong> {customer.postal_code}\n"
+        f"📞 <strong>Телефон:</strong> {customer.phone_for_display}\n\n"
+        f"🧾 <strong>Товары:</strong>\n{items_block}\n\n"
+        f"💰 <strong>Итого:</strong> {cart.total_text}$"
     )
 
 


### PR DESCRIPTION
## Summary
- add celebratory emojis across the user-facing order confirmation summary, including labeled fields and cart lines
- enrich the admin notification with icons and bold formatting for key fields

## Testing
- python -m compileall handlers/order_processing.py

------
https://chatgpt.com/codex/tasks/task_e_68d02038a160832d81809fb2cef20e1c