### PR TITLE
Add group admin management commands

### DIFF
--- a/database/orm_query.py
+++ b/database/orm_query.py
@@ -208,6 +208,27 @@ async def orm_add_user(
         await session.commit()
 
 
+async def orm_update_user_admin_status(
+    session: AsyncSession,
+    user_id: int,
+    is_admin: bool,
+    *,
+    first_name: str | None = None,
+    last_name: str | None = None,
+) -> bool:
+    values: dict[str, object] = {"is_admin": is_admin}
+    if first_name is not None:
+        values["first_name"] = first_name
+    if last_name is not None:
+        values["last_name"] = last_name
+
+    result = await session.execute(
+        update(User).where(User.user_id == user_id).values(**values)
+    )
+    await session.commit()
+    return result.rowcount > 0
+
+
 ######################## Работа с корзинами #######################################
 
 async def orm_add_to_cart(session: AsyncSession, user_id: int, product_id: int):

--- a/handlers/admin_hendlers/__init__.py
+++ b/handlers/admin_hendlers/__init__.py
@@ -10,6 +10,7 @@ from .banner import register_banner_handlers
 from .catalog import register_catalog_handlers
 from .category import register_category_handlers
 from .common import send_admin_menu
+from .group_admins import group_admin_router
 
 admin_router = Router()
 admin_router.message.filter(ChatTypeFilter(["private"]), IsAdmin())
@@ -40,3 +41,5 @@ register_add_product_handlers(admin_router)
 register_catalog_handlers(admin_router)
 register_category_handlers(admin_router)
 register_banner_handlers(admin_router)
+
+__all__ = ("admin_router", "group_admin_router")

--- a/handlers/admin_hendlers/group_admins.py
+++ b/handlers/admin_hendlers/group_admins.py
@@ -1,0 +1,113 @@
+from aiogram import Router, types
+from aiogram.filters import Command
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from database.orm_query import (
+    orm_add_user,
+    orm_get_user,
+    orm_update_user_admin_status,
+)
+from filters.chat_types import ChatTypeFilter, IsAdmin
+
+
+group_admin_router = Router()
+group_admin_router.message.filter(ChatTypeFilter(["group", "supergroup"]), IsAdmin())
+
+
+def _extract_target_user(message: types.Message) -> types.User | None:
+    reply = message.reply_to_message
+    if not reply:
+        return None
+
+    user = reply.from_user
+    if user is None or user.is_bot:
+        return None
+
+    return user
+
+
+def _format_user_name(user: types.User) -> str:
+    parts: list[str] = []
+
+    if user.full_name:
+        parts.append(user.full_name)
+
+    if user.username:
+        parts.append(f"@{user.username}")
+
+    if not parts:
+        return f"id:{user.id}"
+
+    return " ".join(dict.fromkeys(parts))
+
+
+@group_admin_router.message(Command("add_admin"))
+async def add_admin_command(message: types.Message, session: AsyncSession) -> None:
+    target_user = _extract_target_user(message)
+
+    if target_user is None:
+        await message.reply(
+            "Чтобы назначить администратора, ответьте командой /add_admin "
+            "на сообщение нужного пользователя."
+        )
+        return
+
+    db_user = await orm_get_user(session, target_user.id)
+    if db_user and db_user.is_admin:
+        await message.reply(
+            f"{_format_user_name(target_user)} уже является администратором."
+        )
+        return
+
+    if db_user:
+        await orm_update_user_admin_status(
+            session,
+            target_user.id,
+            True,
+            first_name=target_user.first_name,
+            last_name=target_user.last_name,
+        )
+    else:
+        await orm_add_user(
+            session,
+            target_user.id,
+            first_name=target_user.first_name,
+            last_name=target_user.last_name,
+            is_admin=True,
+        )
+
+    await message.reply(
+        f"{_format_user_name(target_user)} назначен администратором."
+    )
+
+
+@group_admin_router.message(Command("remove_admin"))
+async def remove_admin_command(message: types.Message, session: AsyncSession) -> None:
+    target_user = _extract_target_user(message)
+
+    if target_user is None:
+        await message.reply(
+            "Чтобы снять права администратора, ответьте командой /remove_admin "
+            "на сообщение нужного пользователя."
+        )
+        return
+
+    db_user = await orm_get_user(session, target_user.id)
+    if not db_user or not db_user.is_admin:
+        await message.reply(
+            f"{_format_user_name(target_user)} не является администратором."
+        )
+        return
+
+    await orm_update_user_admin_status(
+        session,
+        target_user.id,
+        False,
+        first_name=target_user.first_name,
+        last_name=target_user.last_name,
+    )
+
+    await message.reply(
+        f"{_format_user_name(target_user)} больше не является администратором."
+    )

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ from database.engine import create_db, drop_db, session_maker
 
 from handlers.user_private import user_private_router
 from handlers.user_group import user_group_router
-from handlers.admin_hendlers import admin_router
+from handlers.admin_hendlers import admin_router, group_admin_router
 from handlers.order_processing import order_router
 
 # ALLOWED_UPDATES = ['message', 'edited_message', 'callback_query']
@@ -33,8 +33,9 @@ bot = Bot(
 dp = Dispatcher()
 
 dp.include_router(user_private_router)
-dp.include_router(user_group_router)
 dp.include_router(admin_router)
+dp.include_router(group_admin_router)
+dp.include_router(user_group_router)
 dp.include_router(order_router)
 
 async def on_startup(bot):


### PR DESCRIPTION
## Summary
- add a reusable helper to update the admin flag for users in the database
- implement /add_admin and /remove_admin commands for group chats to grant or revoke admin rights via replies
- register the new group admin router so the commands are processed alongside existing handlers

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d1ace7eb58832dbddd45d05f1cfe99