### PR TITLE
Hide coordinates in order summary and show ruble prices

### DIFF
--- a/handlers/menu_processing.py
+++ b/handlers/menu_processing.py
@@ -19,6 +19,8 @@ from kbds.inline import (
 )
 from utils.paginator import Paginator
 from aiogram.types import InputMediaPhoto, FSInputFile
+from utils.money import format_money
+from utils.order import CURRENCY_SYMBOL
 
 
 BANNERS_DIR = Path(__file__).resolve().parents[1] / "banners"
@@ -137,7 +139,9 @@ async def products(session, level, category, page):
     caption_parts = [f"<strong>{product.name}</strong>"]
     if details_line:
         caption_parts.append(details_line)
-    caption_parts.append(f"Стоимость: {round(product.price, 2)}")
+    caption_parts.append(
+        f"Стоимость: {format_money(product.price)} {CURRENCY_SYMBOL}"
+    )
     caption_parts.append(
         f"<strong>Товар {paginator.page} из {paginator.pages}</strong>"
     )
@@ -179,16 +183,19 @@ async def carts(session, level, menu_name, page, user_id, product_id):
         paginator = Paginator(carts, page=page)
         cart = paginator.get_page()[0]
 
-        cart_price = round(cart.quantity * cart.product.price, 2)
-        total_price = round(sum(c.quantity * c.product.price for c in carts), 2)
+        cart_price = format_money(cart.quantity * cart.product.price)
+        total_price = format_money(
+            sum(c.quantity * c.product.price for c in carts)
+        )
+        product_price = format_money(cart.product.price)
 
         image = InputMediaPhoto(
             media=cart.product.image,
             caption=(
                 f"<strong>{cart.product.name}</strong>\n"
-                f"{cart.product.price}$ x {cart.quantity} = {cart_price}$\n"
+                f"{product_price} {CURRENCY_SYMBOL} x {cart.quantity} = {cart_price} {CURRENCY_SYMBOL}\n"
                 f"Товар {paginator.page} из {paginator.pages} в корзине.\n"
-                f"Общая стоимость товаров в корзине {total_price}$"
+                f"Общая стоимость товаров в корзине {total_price} {CURRENCY_SYMBOL}"
             ),
         )
 

--- a/handlers/order_processing.py
+++ b/handlers/order_processing.py
@@ -23,6 +23,7 @@ from handlers.menu_processing import get_menu_content
 from kbds.inline import MenuCallBack
 from utils import get_address_from_coords, prettify_address
 from utils.order import (
+    CURRENCY_SYMBOL,
     CartData,
     CustomerData,
     build_admin_notification,
@@ -69,7 +70,7 @@ def build_review_text(cart_lines: list[str], total_text: str) -> str:
         "🛍️ <strong>Оформление заказа</strong>\n\n"
         "🔎 Проверьте содержимое корзины перед оформлением.\n\n"
         f"🧺 <strong>Корзина:</strong>\n{cart_text}\n\n"
-        f"💳 <strong>Итого:</strong> {total_text}$\n\n"
+        f"💳 <strong>Итого:</strong> {total_text} {CURRENCY_SYMBOL}\n\n"
         "Нажмите «Подтвердить», чтобы продолжить, или «Назад», чтобы вернуться."
     )
 
@@ -312,28 +313,14 @@ def order_summary_text(data: dict) -> str:
     address = data.get("address") or "—"
     phone = data.get("phone") or "—"
 
-    lat_value = data.get("lat")
-    lon_value = data.get("lon")
-    coords_line = ""
-    try:
-        lat_float = float(lat_value)
-        lon_float = float(lon_value)
-    except (TypeError, ValueError):
-        lat_float = lon_float = None
-    if lat_float is not None and lon_float is not None:
-        coords_line = (
-            f"🗺️ <strong>Координаты:</strong> {lat_float:.5f}, {lon_float:.5f}\n"
-        )
-
     return (
         "🔎 <strong>Проверьте данные заказа</strong>\n\n"
         f"👤 <strong>ФИО:</strong> {full_name}\n"
         f"📍 <strong>Адрес:</strong> {address}\n"
         f"📮 <strong>Индекс:</strong> {postal_code}\n"
-        f"{coords_line if coords_line else ''}"
         f"📞 <strong>Телефон:</strong> {phone}\n\n"
         f"🧺 <strong>Корзина:</strong>\n{cart_block}\n\n"
-        f"💰 <strong>Итого:</strong> {total}$"
+        f"💰 <strong>Итого:</strong> {total} {CURRENCY_SYMBOL}"
     )
 
 

--- a/utils/order.py
+++ b/utils/order.py
@@ -7,6 +7,9 @@ from typing import Awaitable, Callable, Mapping, Sequence
 from utils.money import format_money, to_decimal
 
 
+CURRENCY_SYMBOL = "₽"
+
+
 def _parse_float(value: object) -> float | None:
     try:
         if value is None:
@@ -131,8 +134,8 @@ class CartData:
             name = str(cart.product.name)
             lines.append(
                 (
-                    f"{idx}. {name} — {format_money(price)}$ "
-                    f"× {quantity} = {format_money(subtotal)}$"
+                    f"{idx}. {name} — {format_money(price)} {CURRENCY_SYMBOL} "
+                    f"× {quantity} = {format_money(subtotal)} {CURRENCY_SYMBOL}"
                 )
             )
             items.append(
@@ -187,7 +190,7 @@ def build_admin_notification(order_id: int, customer: CustomerData, cart: CartDa
         f"{coords_line}"
         f"📞 <strong>Телефон:</strong> {customer.phone_for_display}\n\n"
         f"🧾 <strong>Товары:</strong>\n{items_block}\n\n"
-        f"💰 <strong>Итого:</strong> {cart.total_text}$"
+        f"💰 <strong>Итого:</strong> {cart.total_text} {CURRENCY_SYMBOL}"
     )
 
 


### PR DESCRIPTION
## Summary
- hide customer coordinates from order confirmation texts
- show cart and product totals in rubles using a shared currency symbol

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d4f5626828832dbea2fd4401a0e96f